### PR TITLE
Use empty string as default doc string for defconst.

### DIFF
--- a/core.lisp
+++ b/core.lisp
@@ -141,7 +141,7 @@ from <_:arg parent-packages /> and adding them to :use'd packages.
             (list parent-symbols parent-packages))
     `(defpackage ,name ,@defpackage-options)))
 
-(defmacro defconst (name value &optional doc)
+(defmacro defconst (name value &optional (doc ""))
   "<_:fun Defconstant /> only, whent it's not already defined"
   `(eval-always
      (unless (boundp ',name)


### PR DESCRIPTION
Hi,

I'm using rutils with Clozure Common Lisp 1.7.

When it compiles iter.lisp, defconst +fill-col+ doesn't supply a doc string, and then CCL complains that defconstant (called from the defconst macro) is using nil rather than a string as the doc string.

This patch makes it compile.

I do not have much experience with CL so I will not feel bad if you reject this patch but I would appreciate it (if you reject it) if you tell my what I did wrong.

cheers,
Matt
