### PR TITLE
Fixes of anaphoric macros

### DIFF
--- a/core/anaphoric.lisp
+++ b/core/anaphoric.lisp
@@ -8,35 +8,35 @@
 
 (eval-always
 
-(defmacro if-it (test then &optional else)
+(defmacro! if-it (test then &optional else)
   "Like IF. IT is bound to TEST."
-  `(let ((it ,test))
-     (if it ,then ,else)))
+  `(let ((,e!-it ,test))
+     (if ,e!-it ,then ,else)))
 
-(defmacro when-it (test &body body)
+(defmacro! when-it (test &body body)
   "Like WHEN. IT is bound to TEST."
-  `(let ((it ,test))
-     (when it
+  `(let ((,e!-it ,test))
+     (when ,e!-it
        ,@body)))
 
-(defmacro and-it (&rest args)
+(defmacro! and-it (&rest args)
   "Like AND. IT is bound to the value of the previous AND form."
   (cond ((null args) t)
         ((null (cdr args)) (car args))
         (t `(when-it ,(car args) (and-it ,@(cdr args))))))
 
-(defmacro dowhile-it (test &body body)
+(defmacro! dowhile-it (test &body body)
   "Like DOWHILE. IT is bound to TEST."
-  `(do ((it ,test ,test))
-       ((not it))
+  `(do ((,e!-it ,test ,test))
+       ((not ,e!-it))
      ,@body))
 
 (defmacro cond-it (&body body)
   "Like COND. IT is bound to the passed COND test."
-  `(let (it)
+  `(let (,e!-it)
      (cond
        ,@(mapcar (lambda (clause)
-                   `((setf it ,(car clause)) ,@(cdr clause)))
+                   `((setf ,e!-it ,(car clause)) ,@(cdr clause)))
                  ;; uses the fact, that SETF returns the value set
                  body))))
 

--- a/core/packages.lisp
+++ b/core/packages.lisp
@@ -53,30 +53,31 @@
   (:nicknames #:rutils.anaphoric/a #:rutils.ana/a)
   (:documentation "Anaphoric control constructs with a- prefix and
 automatic binding of test to it.")
-  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax)
+  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax
+	#:defmacro-enhance)
   (:export #:aand
            #:acond
            #:adowhile
            #:aif
-           #:awhen
-           #:it))
+           #:awhen))
 
 (defpackage #:reasonable-utilities.anaphoric/it
   (:nicknames #:rutils.anaphoric/it #:rutils.ana/it)
   (:documentation "Anaphoric control constructs with -it suffix and
 automatic binding of test to it.")
-  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax)
+  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax
+	#:defmacro-enhance)
   (:export #:and-it
            #:cond-it
            #:dowhile-it
            #:if-it
-           #:when-it
-           #:it))
+           #:when-it))
 
 (defpackage #:reasonable-utilities.anaphoric/let
   (:nicknames #:rutils.anaphoric/let #:rutils.ana/let)
   (:documentation "Anaphoric control constructs with -let suffix.")
-  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax)
+  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax
+	#:defmacro-enhance)
   (:export #:and-let
            #:cond-let
            #:dowhile-let
@@ -86,7 +87,8 @@ automatic binding of test to it.")
 (defpackage #:reasonable-utilities.anaphoric/bind
   (:nicknames #:rutils.anaphoric/bind #:rutils.ana/bind)
   (:documentation "Anaphoric control constructs with -bind suffix.")
-  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax)
+  (:use :common-lisp #:rutils.readtable #:rutils.symbol #:rutils.syntax
+	#:defmacro-enhance)
   (:export #:and-bind
            #:cond-bind
            #:dowhile-bind

--- a/rutils.asd
+++ b/rutils.asd
@@ -14,7 +14,7 @@ extension and basic data-structures hadling, developed over the years of
 CL history by efforts of different individuals, and gathered under
 the unbrella of a hierarchy of packages, which can be used
 selectively on demand."
-  :depends-on (#:named-readtables)
+  :depends-on (#:named-readtables #:defmacro-enhance)
   :serial t
   :components
   ((:module #:core


### PR DESCRIPTION
Hi!
Your anaphoric macros (which automatically binded IT to the result of the calculation)
had a problem, that when used from the other package, IT in the macro-code and IT
in the BODY, supplied by the programmer were actually 2 different IT's, belonging to
2 different packages.
# :it in the declaration of the package were not solving the problem, since this symbol is for exporting functions, not symbols, the working (but ugly) version would be

::it.

However, I propose a cleaner solution (encompassed in my package DEFMACRO-ENHANCE).
It literally reduces to writing DEFMACRO! instead of DEFMACRO where necessary and
substituting IT by ,E!-IT.

I would really appreciate if you would incorporate this fix.
