### PR TITLE
Add #'INTERPOSE

### DIFF
--- a/core/list.lisp
+++ b/core/list.lisp
@@ -79,6 +79,15 @@
                     els)
          list lists))
 
+(defun interpose (separator list)
+  "Returns a sequence of the elements of SEQUENCE separated by SEPARATOR."
+  (labels ((rec (s acc)
+             (if s
+                 (rec (cdr s) (nconc acc
+                                     (list separator (car s))))
+                 acc)))
+    (cdr (rec list nil))))
+
 (defun take (n list &optional (step 1))
   "Return a list with N elements, which are taken from LIST by this formula:
    INDEX of ELEMENT = I * STEP for I from 0"

--- a/core/packages.lisp
+++ b/core/packages.lisp
@@ -114,6 +114,7 @@
            #:flatten
            #:group
            #:interleave
+           #:interpose
            #:last1
            #:listcase
            #:remove-idx

--- a/test/list-test.lisp
+++ b/test/list-test.lisp
@@ -83,6 +83,20 @@
   (should be equal '(:foo :bar)
           (interleave '(:foo :baz) '(:bar))))
 
+(deftest interpose ()
+  (should be null
+          (interpose () ()))
+  (should be null
+          (interpose 1 ()))
+  (should be equal '()
+          (interpose '(:foo) ()))
+  (should be equal '(:foo :baz :bar)
+          (interpose :baz '(:foo :bar)))
+  (should be equal '(:foo (:baz) :bar)
+          (interpose '(:baz) '(:foo :bar)))
+  (should be equal '(:foo :baz :bar :baz :qux)
+          (interpose :baz '(:foo :bar :qux))))
+
 (deftest take ()
   (should be null
           (take 1 ()))


### PR DESCRIPTION
Function similar to interleave, but that interposes a separator between every element in a list. Similar to `strjoin`, but for lists.
