### PR TITLE
Fix zip* test

### DIFF
--- a/test/list-test.lisp
+++ b/test/list-test.lisp
@@ -198,7 +198,7 @@
           (zip* '(:foo :bar) '(:baz 42)))
   (should be equal '((:foo :baz) (:bar nil))
           (zip* '(:foo :bar) '(:baz)))
-  (should be '((:foo) (:bar))
+  (should be equal '((:foo nil) (:bar nil))
           (zip* '(:foo :bar) ())))
 
 (deftest zip*-with ()


### PR DESCRIPTION
I made this change so that tests pass. It seems that `zip*` exibits desired behavior, and the test is wrong.