### PR TITLE
Added more efficience and coverage to RUTILS.SEQUENCE:EMPTYP

### DIFF
--- a/core/list.lisp
+++ b/core/list.lisp
@@ -6,7 +6,7 @@
 
 
 (declaim (inline last1 single dyadic tryadic append1 conc1 ensure-list
-                 dcons dlistp range))
+                 dcons dlistp range concat))
 
 
 (defun last1 (list &optional (n 1))
@@ -304,6 +304,9 @@ incremented by STEP (default 1)."
   (loop :for i :from start :to (1- limit) :by step
      :collect i))
 
+(defun concat (&rest lists)
+  "CONCATENATE all the LISTS into a single list."
+  (apply #'concatenate 'list lists))
 
 ;; D-Lists (see https://groups.google.com/forum/#!msg/comp.lang.lisp/pE-4JL9lnAA/7hiQSBexGLgJ)
 

--- a/core/sequence.lisp
+++ b/core/sequence.lisp
@@ -329,6 +329,9 @@
    is not a sequence."
   (etypecase sequence
     (list (null sequence))
+    (string (rutils.string:blankp sequence))
+    (vector (and (vectorp sequence)
+                 (equalp sequence #())))
     (sequence (zerop (length sequence)))))
 
 (defun equal-lengths (&rest sequences)


### PR DESCRIPTION
Instead of testing whether a vector is empty by calculating its length, it uses a similar comparision from RUTILS.STRING:BLANKP.

Maybe a fifth type could be added to the ETYPECASE: hash-tables? Do you think it makes sense?
Something like:
```lisp
(defun emptyp (sequence)
  "Returns true if SEQUENCE is an empty sequence. Signals an error if SEQUENCE
   is not a sequence."
  (etypecase sequence
    (list (null sequence))
    (string (rutils.string:blankp sequence))
    (vector (and (vectorp sequence)
                 (equalp sequence #())))
    (hash-table (and (hash-table-p sequence)
                     (equalp sequence (make-hash-table))))
    (sequence (zerop (length sequence)))))
```