### PR TITLE
Added CUTSYM, SYMBOL-STARTS-WITH and SYMBOL-ENDS-WITH, and its tests

### DIFF
--- a/core/packages.lisp
+++ b/core/packages.lisp
@@ -146,6 +146,7 @@
         #:rutils.anaphora #:rutils.list)
   (:documentation "String utilities.")
   (:export #:blankp
+           #:cutsym
            #:dolines
            #:ends-with
            #:fmt
@@ -157,6 +158,8 @@
            #:strcat
            #:strjoin
            #:string-designator
+           #:symbol-ends-with
+           #:symbol-starts-with
            #:substr
            #:with-out-file
            #:white-char-p))

--- a/core/string.lisp
+++ b/core/string.lisp
@@ -74,7 +74,7 @@
 
 
 (defun starts-with (prefix string &key (test 'string=))
-  "Test, whether STRING starts with PREFIX."
+  "Test, whether STRING starts with PREFIX. Accepts TEST."
   (if-it (mismatch prefix string :test test)
          (= it (length prefix))
          t))
@@ -84,6 +84,22 @@
   (if-it (mismatch suffix string :from-end t :test test)
          (zerop it)
          t))
+
+(defun cutsym (symbol start &optional end)
+  "Returns a new symbol made of the SUBSTRing from START to END (optional), as in SUBSTR."
+  (let ((substring (substr (symbol-name symbol) start end)))
+    (if (keywordp symbol)
+        (rutils.core:ensure-keyword substring)
+        (rutils.core:ensure-symbol substring))))
+
+(declaim (inline symbol-starts-with symbol-ends-with))
+(defun symbol-starts-with (prefix symbol)
+  "Test, whether SYMBOL starts with PREFIX."
+  (starts-with (symbol-name prefix) (symbol-name symbol)))
+
+(defun symbol-ends-with (suffix symbol)
+  "Test, whether SYMBOL ends with SUFFIX."
+  (ends-with (symbol-name suffix) (symbol-name symbol)))
 
 (deftype string-designator ()
   "A string designator type. It is either a string, a symbol, or a character."

--- a/test/string-test.lisp
+++ b/test/string-test.lisp
@@ -76,6 +76,46 @@
   (should be true
           (ends-with "foo" "FOO" :test 'string-equal)))
 
+(deftest cutsym ()
+  (should be eq 'foo
+          (cutsym 'foo 0))
+  (should be eq 'oo
+          (cutsym 'foo 1))
+  (shoulg be eq 'foo
+          (cutsym 'foo 0 3))
+  (should be eq 'fo
+          (cutysym 'foo 0 -1))
+  (should be eq 'o
+          (cutsym 'o)))
+
+(deftest symbol-starts-with ()
+  (should be null
+          (symbol-starts-with 'foo '||))
+  (should be true
+          (symbol-starts-with '|| 'foo))
+  (should be null
+          (symbol-starts-with 'foo 'fo))
+  (should be true
+          (symbol-starts-with 'foo 'foo))
+  (should be true
+          (symbol-starts-with 'foo 'foobar))
+  (should be true
+          (symbol-starts-with "FOO" )))
+
+(deftest symbol-ends-with ()
+  (should be null
+          (symbol-ends-with 'foo '||))
+  (should be true
+          (symbol-ends-with '|| 'foo))
+  (should be null
+          (symbol-ends-with 'foo 'fo))
+  (should be true
+          (symbol-ends-with 'foo 'foo))
+  (should be true
+          (symbol-ends-with 'bar 'foobar))
+  (should be true
+          (symbol-ends-with "BAR" 'foobar)))
+
 (deftest dolines ()
   (should be equal '("world" "hello")
           (let ((file (fmt "/tmp/~A" (gensym)))


### PR DESCRIPTION
Adds 3 symbol manipulating functions: `CUTSYM`, `SYMBOL-STARTS-WITH` and `SYMBOL-ENDS-WITH`, equivalent to `SUBSTR`, `STARTS-WITH`, and `ENDS-WITH`, but for symbols.

I also added the respective tests.