### PR TITLE
Make #'GROUP work on sequences

### DIFF
--- a/core/list.lisp
+++ b/core/list.lisp
@@ -51,19 +51,6 @@
        (progn ,@body))
      (nreverse ,out)))
 
-(defun group (n list)
-  "Split LIST into a list of lists of length N."
-  (declare (integer n))
-  (when (zerop n)
-    (error "Group length N shouldn't be zero."))
-  (labels ((rec (src acc)
-             (let ((rest (nthcdr n src)))
-               (if (consp rest)
-                   (rec rest (cons (subseq src 0 n) acc))
-                   (nreverse (cons src acc))))))
-    (when list
-      (rec list nil))))
-
 (defun flatten (list)
   "Flatten possibly nested LIST."
   (labels ((rec (x acc)

--- a/core/packages.lisp
+++ b/core/packages.lisp
@@ -113,7 +113,6 @@
            #:dyadic
            #:ensure-list
            #:flatten
-           #:group
            #:interleave
            #:interpose
            #:last1
@@ -196,6 +195,7 @@
            #:doindex
            #:emptyp
            #:equal-lengths
+           #:group
            #:last-elt
            #:length=
            #:nshuffle

--- a/core/sequence.lisp
+++ b/core/sequence.lisp
@@ -424,5 +424,26 @@
            :datum sequence
            :expected-type '(and proper-sequence (not (satisfies emptyp))))))
 
+(defun group (n sequence)
+  "Split SEQUENCE into a list of sequences of length N."
+  (declare (integer n))
+  (when (zerop n)
+    (error "Group length N shouldn't be zero."))
+  (labels ((rec (src acc)
+              (let ((rest (nthcdr n src)))
+                (if (consp rest)
+                    (rec rest (cons (subseq src 0 n) acc))
+                    (nreverse (cons src acc))))))
+    (etypecase sequence
+      (list (rec sequence nil))
+      (null nil)
+      (sequence
+       (do ((i 0 (+ i n))
+            (len (length sequence))
+            (acc nil))
+           ((>= (+ i n) len)
+            (nreverse (push (subseq sequence i) acc)))
+
+         (push (subseq sequence i (+ i n)) acc))))))
 
 (eval-always (pushnew :split-sequence *features*))

--- a/core/sequence.lisp
+++ b/core/sequence.lisp
@@ -434,16 +434,16 @@
                 (if (consp rest)
                     (rec rest (cons (subseq src 0 n) acc))
                     (nreverse (cons src acc))))))
-    (etypecase sequence
-      (list (rec sequence nil))
-      (null nil)
-      (sequence
-       (do ((i 0 (+ i n))
-            (len (length sequence))
-            (acc nil))
-           ((>= (+ i n) len)
-            (nreverse (push (subseq sequence i) acc)))
+    (when sequence
+     (etypecase sequence
+       (list (rec sequence nil))
+       (sequence
+        (do ((i 0 (+ i n))
+             (len (length sequence))
+             (acc nil))
+            ((>= (+ i n) len)
+             (nreverse (push (subseq sequence i) acc)))
 
-         (push (subseq sequence i (+ i n)) acc))))))
+          (push (subseq sequence i (+ i n)) acc)))))))
 
 (eval-always (pushnew :split-sequence *features*))

--- a/test/list-test.lisp
+++ b/test/list-test.lisp
@@ -45,18 +45,6 @@
             (push :foo out)
             (push :bar out))))
 
-(deftest group ()
-  (should be null
-          (group 1 ()))
-  (should be equal '((:foo) (:bar))
-          (group 1 '(:foo :bar)))
-  (should be equal '((:foo :bar))
-          (group 2 '(:foo :bar)))
-  (should be equal '((:foo :bar) (:baz))
-          (group 2 '(:foo :bar :baz)))
-  (should be equal '((:foo :bar) (:baz :foo))
-          (group 2 '(:foo :bar :baz :foo))))
-
 (deftest flatten ()
   (should be null
           (flatten ()))

--- a/test/sequence-test.lisp
+++ b/test/sequence-test.lisp
@@ -172,3 +172,23 @@
           (last-elt '(:foo :bar :baz)))
   (should be char= #\z
           (last-elt "foo bar baz")))
+
+(deftest group ()
+  (should be null
+          (group 1 ()))
+  (should be equal '((:foo) (:bar))
+          (group 1 '(:foo :bar)))
+  (should be equal '((:foo :bar))
+          (group 2 '(:foo :bar)))
+  (should be equal '((:foo :bar) (:baz))
+          (group 2 '(:foo :bar :baz)))
+  (should be equal '((:foo :bar) (:baz :foo))
+          (group 2 '(:foo :bar :baz :foo)))
+  (should be equal '("")
+          (group 3 ""))
+  (should be equal '("a" "b" "c" "d" "e")
+          (group 1 "abcde"))
+  (should be equal '("foo" "bar" "baz" "quu" "x")
+          (group 3 "foobarbazquux"))
+  (should be equal '("foo" "bar" "baz" "qux")
+          (group 3 "foobarbazqux")))


### PR DESCRIPTION
Moved `#'GROUP` from `list.lisp` to `sequence.lisp` and made it work with sequences.

The code that gets called when `#'GROUP` receives a list is the same.

Moved the tests for group to `sequence-test.lisp` and added tests for sequences.