### PR TITLE
toggle-print-hash-table: reenable for ecl/abcl

### DIFF
--- a/core/hash-table.lisp
+++ b/core/hash-table.lisp
@@ -164,8 +164,8 @@ Hash table is initialized using the HASH-TABLE-INITARGS."
                                                in DOTABLE: need an alist"))))
            ,rez)))))
 
-#-(or abcl ecl)
-(let ((default-method (find-method #'print-object nil '(hash-table t)))
+(let ((default-method (ignore-errors (find-method
+                                      #'print-object nil '(hash-table t))))
       toggled)
   (defun toggle-print-hash-table (&optional (on nil explicit))
     "Toggles printing hash-tables with PRINT-HASH-TABLE or with default method.
@@ -177,5 +177,6 @@ Hash table is initialized using the HASH-TABLE-INITARGS."
                  (setf toggled t))
           (progn (remove-method #'print-object
                                 (find-method #'print-object nil '(hash-table t)))
-                 (add-method #'print-object default-method)
+                 (unless (null default-method)
+                   (add-method #'print-object default-method))
                  (setf toggled nil))))))


### PR DESCRIPTION
print-object doesn't have to specialize on ht, so lets verify, if it finds a method.
If it doesn't, wrapper ignore-errors should return nil and we'll know, that there is no such method.