### PR TITLE
Gets rid of pervasive declaim

### DIFF
--- a/core/anaphora.lisp
+++ b/core/anaphora.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.anaphora)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (defmacro if-it (test then &optional else)

--- a/core/array.lisp
+++ b/core/array.lisp
@@ -2,8 +2,8 @@
 
 (cl:in-package #:rutils.array)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
-
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 (deftype array-index (&optional (length array-dimension-limit))
   "Type designator for an index into array of LENGTH: an integer between

--- a/core/core.lisp
+++ b/core/core.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.core)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (define-condition rutils-style-warning (simple-condition style-warning) ())

--- a/core/hash-table.lisp
+++ b/core/hash-table.lisp
@@ -2,7 +2,8 @@
 
 (in-package #:rutils.hash-table)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (declaim (inline sethash))

--- a/core/list.lisp
+++ b/core/list.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.list)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (declaim (inline last1 single dyadic tryadic append1 conc1 ensure-list

--- a/core/misc.lisp
+++ b/core/misc.lisp
@@ -2,7 +2,8 @@
 
 (in-package #:rutils.misc)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 (declaim (inline or2 and2 xor2 void true))
 
 

--- a/core/pair.lisp
+++ b/core/pair.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.pair)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (declaim (inline pair))

--- a/core/readtable.lisp
+++ b/core/readtable.lisp
@@ -1,7 +1,8 @@
 ;; For license see LICENSE
 
 (in-package #:rutils.readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (eval-when (:compile-toplevel :load-toplevel :execute)

--- a/core/sequence.lisp
+++ b/core/sequence.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.sequence)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 (declaim (inline safe-sort map*))
 
 

--- a/core/string.lisp
+++ b/core/string.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.string)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (declaim (inline white-char-p fmt strjoin blankp))

--- a/core/tree.lisp
+++ b/core/tree.lisp
@@ -2,7 +2,8 @@
 
 (cl:in-package #:rutils.tree)
 (named-readtables:in-readtable rutils-readtable)
-(declaim #.+default-opts+)
+(eval-when (:compile-toplevel)
+  (declaim #.+default-opts+))
 
 
 (defmacro dotree ((subtree tree &optional result) &body body)


### PR DESCRIPTION
Hi @vseloved,

This patch just wraps the use of `declaim` around `(eval-when (:compile-toplevel))` to make sure they're contained to the files making use of the relevant optimizations.

Thanks!