### PR TITLE
Allegro compilation fix

### DIFF
--- a/core/anaphora.lisp
+++ b/core/anaphora.lisp
@@ -69,18 +69,3 @@
        ,@(mapcar #``((setf ,var ,(car %)) ,(cadr %))
                  ;; uses the fact, that SETF returns the value set
                  body))))
-
-
-;;; aliases
-
-(abbr aand and-it)
-(abbr acond cond-it)
-(abbr adowhile dowhile-it)
-(abbr aif if-it)
-(abbr awhen when-it)
-
-(abbr and-bind and-let)
-(abbr cond-bind cond-let)
-(abbr dowhile-bind dowhile-let)
-(abbr if-bind if-let)
-(abbr when-bind when-let)

--- a/core/iter.lisp
+++ b/core/iter.lisp
@@ -34,9 +34,10 @@
   `(eval-always
      (setf (get ',symbol 'synonym) ',synonym)))
 
-(defmacro augment (var stuff)
-  "Add STUFF to the end of VAR list."
-  `(setf ,var (nconc ,var ,stuff)))
+(eval-always ; On Allegro, this is required for compiling `define-clause', which is in `eval-always' also.
+  (defmacro augment (var stuff)
+    "Add STUFF to the end of VAR list."
+    `(setf ,var (nconc ,var ,stuff))))
 
 (defmacro prepend (stuff var)
   "Add STUFF to the beginning of VAR list."


### PR DESCRIPTION
At the latest release of rutils, I found some problems for loading it in Allegro Common Lisp. This pull request tries to fix them.

____

On loading "anaphora.lisp", Allegro raised a simple-error saying "Can't abbreviate AND-IT", by `abbr` macro in "symbol.lisp".
This is raised on 'aliases' at the tail of anaphora.lisp.

Apparently, Allegro cannot refer DEFMACROs in the same file at `:compile-toplevel` without specifying the same situation. (This behavior is different from SBCL, so I sometimes confused..)

One way to fix it is wraps `and-it`, `cond-it`, etc with `eval-always`.

But I found "abbr.lisp" has same aliases, and Allegro does not cause any error if DEFMACROs are in another file.
So commit b7adc5b simply deletes aliases in "anaphora.lisp"

____

On loading "iter.lisp", Allegro raised an `UNDEFINED-FUNCTION` error around `RUTILS.ITER::AUGMENT` macro.
This is raised at `define-clause` which is within `eval-always`, so its reason is resembles the above one.

commit 668f748 adds `eval-always` around `RUTILS.ITER::AUGMENT` to fix it.


By the way, I noticed this error because rutils.iter was merged from rutilsx.
I tried to load an older version which rutilsx.iter was still splitted, and I faced same error.
So, it seems this problem potentially stayed in older versions.

____

FIY, I paste backtraces about "iter.lisp" I saw. My platform is here:

    CL-USER> (lisp-implementation-type)
    "International Allegro CL Enterprise Edition"
    
    CL-USER> (lisp-implementation-version)
    "10.1 [64-bit Mac OS X (Intel) *SMP*] (Mar 29, 2019 13:55)"
    ("lisp_build 1036")

Backtraces:

    attempt to call `RUTILS.ITER::AUGMENT' which is an undefined
    function.
       [Condition of type UNDEFINED-FUNCTION]

    Restarts:
     0: [TRY-AGAIN] Try calling RUTILS.ITER::AUGMENT again.
     1: [RETURN-VALUE] Return a value instead of calling RUTILS.ITER::AUGMENT.
     2: [USE-VALUE] Try calling a function other than RUTILS.ITER::AUGMENT.
     3: [STORE-VALUE] Setf the symbol-function of RUTILS.ITER::AUGMENT and call it again.
     4: [NIL] retry the compilation of /Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/iter.lisp
     5: [NIL] continue compiling /Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/iter.lisp but generate no output file
     --more--

    Backtrace:
      0: (ERROR #<UNDEFINED-FUNCTION @ #x10019f9172>)
      1: (LET* ((RUTILS.ITER::REQ-KEYWORDS (MAPCAR #'RUTILS.SYMBOL:ENSURE-KEYWORD RUTILS.ITER::RKWS)) ..))
      2: (MULTIPLE-VALUE-BIND (RUTILS.ITER::RKWS RUTILS.ITER::RVALS RUTILS.ITER::OKWS RUTILS.ITER::OVALS) ..)
      3: (LET () ..)
      4: (FLET ((RUTILS.ITER::MAKE-KEYWORD-SPEC (RUTILS.ITER::KW RUTILS.ITER::VAL) (IF # `# `#))) ..)
      5: (RUTILS.ITER::DEFINE-CLAUSE DEFUN (:FOR RUTILS.ITER::VAR-SPEC RUTILS.ITER::&SEQUENCE) ..)
      6: (LET* ((#:G4036 (CDR EXCL::**MACROARG**)) (RUTILS.ITER::CLAUSE-TEMPLATE (EXCL::CAR-FUSSY #:G4036 'RUTILS.ITER::CLAUSE-TEMPLATE)) (RUTILS.ITER::BODY (CDR #:G4036))) ..)
      7: (LET* () (LET* ((#:G4036 #) (RUTILS.ITER::CLAUSE-TEMPLATE #) (RUTILS.ITER::BODY #)) (RUTILS.ITER::DEFINE-CLAUSE 'DEFUN RUTILS.ITER::CLAUSE-TEMPLATE RUTILS.ITER::BODY T)))
      8: (RUTILS.ITER:DEFCLAUSE-DRIVER ..)
      9: (FUNCALL #<Interpreted Macro Function DEFCLAUSE-DRIVER @ #x10018b1e42> ..)
     10: ((:INTERNAL QUICKLISP-CLIENT::MACROEXPAND-PROGRESS-FUN 0) #<Interpreted Macro Function DEFCLAUSE-DRIVER @ #x10018b1e42> ..)
     11: (COMPILER::COMPILE-PROCESS-FORM #(((#:G4547 :TOP-LEVEL-FORM "/Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/iter.lisp" 92757)) NIL NIL 0 0 NIL ...) ..)
     12: ((FLET COMPILE-FILE EXCL::CONTINUATION))
     13: (COMPILE-FILE #P"/Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/iter.lisp" ..)
     14: ((:INTERNAL (:INTERNAL (:INTERNAL UIOP/LISP-BUILD:COMPILE-FILE* 0) 0) 0))
     15: (UIOP/UTILITY:CALL-WITH-MUFFLED-CONDITIONS #<Closure (:INTERNAL (:INTERNAL # 0) 0) @ #x10017cb702> NIL)
     16: (UIOP/LISP-BUILD:CALL-WITH-MUFFLED-COMPILER-CONDITIONS #<Closure (:INTERNAL (:INTERNAL # 0) 0) @ #x10017cb702>)
     17: ((:INTERNAL (:INTERNAL UIOP/LISP-BUILD:COMPILE-FILE* 0) 0))
     18: (UIOP/LISP-BUILD::CALL-WITH-SAVED-DEFERRED-WARNINGS #<Closure (:INTERNAL (:INTERNAL UIOP/LISP-BUILD:COMPILE-FILE* 0) 0) @ #x10017cb7e2> NIL ..)
     19: ((:INTERNAL UIOP/LISP-BUILD:COMPILE-FILE* 0) #P"/Users/yokota/quicklisp/dists/quicklisp/software/rutils-20191007-git/core/iter.lisp")
