### PR TITLE
core/iter: Fix “:by” clause in numerical iteration

### DIFF
--- a/core/iter.lisp
+++ b/core/iter.lisp
@@ -1247,7 +1247,7 @@ as generators."
 (eval-always
   (defparameter +sequence-keyword-list+
     '(:from from :upfrom upfrom :downfrom downfrom :to to :downto downto
-      :above above :below below (:by 1) (by 1) :with-index with-index)
+      :above above :below below :by (by 1) :with-index with-index)
     "Keywords, used in sequence iteration clauses.")
 
   (defun define-clause (define-form clause-template body generator?)


### PR DESCRIPTION
This is reverting back to what is present in the original "iterate"
code; I’m not sure what prompted this change in rutils but this
version is present in git since the file was added.  The existing
version with the extra parens was triggering an "Unknown keyword BY"
error in all attempts to use :by in a numerial :for loop, eg:
```
(iter (:for i :from 0 :below 10 :by 2) (print i))

Iterate, in (FOR I FROM 0 BELOW 10 BY 2):
Unknown keyword BY
   [Condition of type SIMPLE-ERROR]
```
Tested with sbcl 2.0.0 from nixpkgs.