### PR TITLE
Update rutilsx-test.asd

### DIFF
--- a/rutilsx-test.asd
+++ b/rutilsx-test.asd
@@ -15,4 +15,4 @@
   :depends-on (#:rutilsx #:should-test)
   :components
   ((:module #:test
-            :components ((:file "packagex"))))))
+            :components ((:file "packagex")))))


### PR DESCRIPTION
While packing for Guix I've encountered with this issue

```
starting phase `build'
Invoking sbcl: "/gnu/store/i8wj59i9x3p8k253jmhxn5hi2iw0x4hw-sbcl-2.1.4/bin/sbcl" "--non-interactive" "--eval" "(require :asdf)" "--eval" "(asdf:load-asd (truename \"/gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutils-test.asd\"))" "--eval" "(asdf:load-asd (truename \"/gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutils.asd\"))" "--eval" "(asdf:load-asd (truename \"/gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutilsx-test.asd\"))" "--eval" "(asdf:load-asd (truename \"/gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutilsx.asd\"))" "--eval" "(asdf:compile-system \"rutils\")"
This is SBCL 2.1.4, an implementation of ANSI Common Lisp.
More information about SBCL is available at <http://www.sbcl.org/>.

SBCL is free software, provided as is, with absolutely no warranty.
It is mostly in the public domain; some portions are provided under
BSD-style licenses.  See the CREDITS and COPYING files in the
distribution for more information.
Unhandled LOAD-SYSTEM-DEFINITION-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING {1001870103}>: Error while trying to load definition for system rutilsx-test from pathname /gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutilsx-test.asd: READ error during LOAD: unmatched close parenthesis Line: 18, Column: 48, File-Position: 560 Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /gnu/store/8g8xw4fg9nams9ay7ziha63aads8lwzr-sbcl-rutils-5.2.1-1.db3c3f4/share/common-lisp/sbcl/rutils/rutilsx-test.asd" {10057A0613}>
```