### PR TITLE
rutils.iter: fix defclause-sequence drivers

### DIFF
--- a/core/iter.lisp
+++ b/core/iter.lisp
@@ -2000,7 +2000,7 @@ the body of the loop, so it must not contain anything that depends on the body."
          (seq-code (or seq-var sequence))
          (step-var (unless (constant? by)
                      (make-var-and-default-binding 'step :type 'fixnum)))
-         (step (or step-var by))
+         (step (or step-var by 1))
          (step-func (if (or downto downfrom above) '- '+))
          (test-func (cond (to '>)
                           ((or downto downfrom) '<)

--- a/test/iter-test.lisp
+++ b/test/iter-test.lisp
@@ -5,3 +5,7 @@
 (cl:in-package #:rutils.test)
 (named-readtables:in-readtable rutils-readtable)
 
+(deftest iter ()
+  (should be equal '(#\a #\b #\c)
+          (iter (:for c :in-string "abc")
+            (:collect c))))


### PR DESCRIPTION
Defaults `step` in `return-seq-code` to 1.

Currently, all drivers that use `defclause-sequence` are broken, because `step` is not bound before `return-sequence-code` is called. This results in `step` being bound to nil, which means `initial-value` is set to `(- nil)` and `step-code` is set to something like `(+ index nil)`. This change causes `step` to default to 1 if it is not provided.

Fixes #61 #67 