### PR TITLE
Transfer setf definitions if any in abbr.

### DIFF
--- a/core/symbol.lisp
+++ b/core/symbol.lisp
@@ -38,6 +38,9 @@
           (error "Can't abbreviate a special-operator ~a" ',long))
          ((fboundp ',long)
           (setf (fdefinition ',short) (fdefinition ',long))
+          ;; Migrate the setf definitions as well if any.
+          (when (fboundp '(setf ,long))
+            (setf (fdefinition '(setf ,short)) (function (setf ,long))))
           #+ccl (setf (ccl:arglist ',short) (ccl:arglist ',long))
           ,(when lambda-list
             `(define-setf-expander ,short ,lambda-list

--- a/test/pair-test.lisp
+++ b/test/pair-test.lisp
@@ -17,3 +17,13 @@
           (pairs->ht ()))
   (should be equalp #h(equal :l :r "l" "r")
           (pairs->ht (list (pair :l :r) (pair "l" "r")) :test 'equal)))
+
+(deftest setfable/lt ()
+  (should be eq t
+          (handler-case (progn (setf (rutil:lt (rutil:pair 0 0)) 1) t)
+            (error (e) (declare (ignore e)) nil))))
+
+(deftest setfable/rt ()
+  (should be eq t
+          (handler-case (progn (setf (rutil:rt (rutil:pair 0 0)) 1) t)
+            (error (e) (declare (ignore e)) nil))))


### PR DESCRIPTION
This commit supports the macro `abbr` to transfer `setf` definitions for the function `long` to the abbreviated function `short`.

Provide two tests as well. Here's how you test:
``` lisp
(should-test:test :package 'rutils.test)
```

It resolves the issue(s): https://github.com/vseloved/rutils/issues/63 .

``` lisp
;;; Example usage
(setf (rutil:lt (rutil:pair 0 0)) 1) ; => 1
(setf (rutil:rt (rutil:pair 0 0)) 1) ; => 1
```

---

Tested with
```
(should-test:test :package (find-package :rutils.test))
(should-test:test :package (find-package :rtl)) ; 5 failures, but those are presented in the master  branch already.
```