### PR TITLE
Remove inlining the macro void.

### DIFF
--- a/core/misc.lisp
+++ b/core/misc.lisp
@@ -4,7 +4,7 @@
 (named-readtables:in-readtable rutils-readtable)
 (eval-when (:compile-toplevel)
   (declaim #.+default-opts+))
-(declaim (inline or2 and2 xor2 void true))
+(declaim (inline or2 and2 xor2 true))
 
 
 ;;; predicates and other logical operations


### PR DESCRIPTION
According to the standard (Declaration INLINE), inlining macros has no effect (nor an error), unless a compiler macro is provided for the name.

>    inline and notinline declarations otherwise have no effect when the
>    lexically visible definition of function-name is a macro
>    definition.

cf. https://www.lispworks.com/documentation/HyperSpec/Body/d_inline.htm#inline

Resolve issue(s): https://github.com/vseloved/rutils/issues/59 .

Tested with
```
(should-test:test :package (find-package :rutils.test))
(should-test:test :package (find-package :rtl)) ; 5 failures, but those are presented in the master  branch already.
```