### PR TITLE
Fix lambda macro having parameters in wrong namespace

### DIFF
--- a/core/readtable.lisp
+++ b/core/readtable.lisp
@@ -110,9 +110,11 @@
                                      sexp))))
 
 (defmacro trivial-positional-lambda (body)
-  `(lambda (&optional % %%)
-     (declare (ignorable %) (ignorable %%))
-     ,body))
+  (let ((% (intern "%"))
+        (%% (intern "%%")))
+    `(lambda (&optional ,% ,%%)
+       (declare (ignorable ,%) (ignorable ,%%))
+       ,body)))
 
 (defun |#/-reader| (stream char arg)
   "Literal syntax for raw strings (which don't need escapin of control chars).


### PR DESCRIPTION
When using the `^()` macro, it sometimes declares the argument variables into the `rutils.readtable` package, instead of the current package. For example:
```lisp
(macroexpand '^(+ % %%))
; produces
#'(LAMBDA (&OPTIONAL RUTILS.READTABLE:% RUTILS.READTABLE:%%)
  (DECLARE (IGNORABLE RUTILS.READTABLE:%) (IGNORABLE RUTILS.READTABLE:%%))
  (+ % %%))
```

As you can see, the `%` and `%%` variables used in `+` are not the same as the ones defined as a parameter, so this will error. The solution is to use `INTERN`, so that the `%` and `%%` variables are declared in the correct package (the current one in the evaluation of the macro).